### PR TITLE
return when no query is given

### DIFF
--- a/js/holmes.js
+++ b/js/holmes.js
@@ -89,6 +89,11 @@
         // search in lowercase
         var searchString = search.value.toLowerCase();
 
+        // early return if search string is empty
+        if (!searchString) {
+          return;
+        }
+
         // loop over all the elements
         // in case this should become dynamic, query for the elements here
         for (var i = 0; i < elements.length; i++) {


### PR DESCRIPTION
that will avoid a loop over all of the elements and make emptying the query faster. Suggested by @aarohmankad in https://github.com/aarohmankad/holmes/commit/e2243ef00a3855ed68ec8fb452afbe8577fcac10
