### PR TITLE
don't take minCharacters in account when no search term

### DIFF
--- a/js/holmes.js
+++ b/js/holmes.js
@@ -149,7 +149,7 @@
         // if a minimum of characters is required
         // check if that limit has been reached
         if (options.minCharacters) {
-          if (options.minCharacters > search.value.length) {
+          if (options.minCharacters > search.value.length && search.value.length !== 0) {
             return;
           }
         }


### PR DESCRIPTION
Since when a user resets a form, it's expected to take changes in account (i.e. show all items again).

fixes #50
