### PR TITLE
fix onFound callback to be called when the very first element is visible

### DIFF
--- a/__tests__/holmes.js
+++ b/__tests__/holmes.js
@@ -375,7 +375,7 @@ describe('options', () => {
           return input('');
         })
         .then(() => {
-          expect(callback).toBeCalled();
+          expect(callback).toHaveBeenCalledTimes(1);
         });
     });
   });

--- a/js/main.js
+++ b/js/main.js
@@ -250,15 +250,16 @@ class Holmes {
         ) {
           this._showElement(element);
 
-          if (empty && typeof this.options.onFound === 'function') {
-            this.options.onFound(this.placeholderNode);
-          }
           // The element is now found at least once
           found = true;
         } else {
           this._hideElement(element);
         }
       });
+
+      if (found && empty && typeof this.options.onFound === 'function') {
+        this.options.onFound(this.placeholderNode);
+      }
 
       if (typeof this.options.onInput === 'function') {
         this.options.onInput(this.searchString);


### PR DESCRIPTION
**Summary:**
`onFound` test was checking that the callback was called (but it was being called for every found item), so I've put a number of times that can be called when the input is changed, in order to fix the issue.  :tada:

Related issue: https://github.com/Haroenv/holmes/issues/87 